### PR TITLE
Fixed issue #106

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -121,7 +121,7 @@ class FocalLoss(nn.Module):
                 targets = targets/torch.Tensor([[0.1, 0.1, 0.2, 0.2]]).cuda()
 
 
-                negative_indices = 1 - positive_indices
+                negative_indices = ~positive_indices
 
                 regression_diff = torch.abs(targets - regression[positive_indices, :])
 


### PR DESCRIPTION
This issue fixes issue #106: 
```
Subtraction, the - operator, with a bool tensor is not supported. If you are trying to invert a mask, use the ~ or bitwise_not() operator instead.
```
The issue is solved by replacing `1 - positive_indices` by `~ positive_indices`